### PR TITLE
fix: fix parse old-ver uipath logfile bug&add test

### DIFF
--- a/server/src/app-config.ts
+++ b/server/src/app-config.ts
@@ -7,8 +7,14 @@ const getServerConfig = () => {
     CLIENT_PORT: string
     SERVER_PORT: string
   }
+  let configPath = ''
 
-  const configPath = process.cwd() + '\\server.config.json'
+  if (process.platform === 'linux') {
+    configPath = process.cwd() + '/server.config.json'
+  } else {
+    // win32 or others
+    configPath = process.cwd() + '\\server.config.json'
+  }
   console.log('Server Config File Path: ' + configPath)
   const serverConfig = fs.readFileSync(configPath, 'utf8')
   if (serverConfig === '') {

--- a/server/src/core/__test__/file-name.spec.ts
+++ b/server/src/core/__test__/file-name.spec.ts
@@ -1,0 +1,17 @@
+import path from 'path'
+import { getFilesName } from '../file-name-analyzer'
+
+describe('parse and get file name all right', () => {
+  test('parse file name', () => {
+    const expected = ['2023-02-02_Execution.log', '2023-02-10_Execution.log']
+    const testFolderPath = path.join(__dirname, './test-logs')
+    const fileNameArr = getFilesName(testFolderPath)
+    expect(2).toBe(fileNameArr.length)
+    expect(expected).toEqual(expect.arrayContaining(fileNameArr))
+    expect([
+      '2023-02-02_WorkflowAnalyzer_Execution.log',
+      '2023-02-10_WorkflowAnalyzer_Execution.log'
+    ]).not.toEqual(expect.arrayContaining(fileNameArr))
+    //
+  })
+})

--- a/server/src/core/__test__/file-name.spec.ts
+++ b/server/src/core/__test__/file-name.spec.ts
@@ -1,17 +1,21 @@
-import path from 'path'
-import { getFilesName } from '../file-name-analyzer'
+import { filterLogsFile } from '../file-name-analyzer'
 
 describe('parse and get file name all right', () => {
-  it('parse file name', () => {
+  it('parse and filter file name', () => {
+    const testLogsFileArr = [
+      '2023-02-02_WorkflowAnalyzer_Execution.log',
+      '2023-02-02_Execution.log',
+      '2023-02-10_WorkflowAnalyzer_Execution.log',
+      '2023-02-10_Execution.log'
+    ]
     const expected = ['2023-02-02_Execution.log', '2023-02-10_Execution.log']
-    const testFolderPath = path.join(__dirname, './test-logs')
-    const fileNameArr = getFilesName(testFolderPath)
-    expect(2).toBe(fileNameArr.length)
-    expect(expected).toEqual(expect.arrayContaining(fileNameArr))
+    const filteredArr = testLogsFileArr.filter((item) => filterLogsFile(item))
+    expect(2).toBe(filteredArr.length)
+    expect(expected).toEqual(expect.arrayContaining(filteredArr))
     expect([
       '2023-02-02_WorkflowAnalyzer_Execution.log',
       '2023-02-10_WorkflowAnalyzer_Execution.log'
-    ]).not.toEqual(expect.arrayContaining(fileNameArr))
+    ]).not.toEqual(expect.arrayContaining(filteredArr))
     //
   })
 })

--- a/server/src/core/__test__/file-name.spec.ts
+++ b/server/src/core/__test__/file-name.spec.ts
@@ -2,7 +2,7 @@ import path from 'path'
 import { getFilesName } from '../file-name-analyzer'
 
 describe('parse and get file name all right', () => {
-  test('parse file name', () => {
+  it('parse file name', () => {
     const expected = ['2023-02-02_Execution.log', '2023-02-10_Execution.log']
     const testFolderPath = path.join(__dirname, './test-logs')
     const fileNameArr = getFilesName(testFolderPath)

--- a/server/src/core/file-name-analyzer.ts
+++ b/server/src/core/file-name-analyzer.ts
@@ -8,11 +8,15 @@ import { IFileInfoObj } from '../types/log-types'
  * @param uipathFolderPath uipath log storage path
  * @returns all log files name
  */
-const getFilesName = (uipathFolderPath: string): string[] => {
+export const getFilesName = (uipathFolderPath: string): string[] => {
+  // fixed: At Uipath 2019.10.* old version has `2023-02-10_WorkflowAnalyzer_Execution.log`
   // get all files name
-  const filesNameArr = fs
-    .readdirSync(uipathFolderPath, 'utf8')
-    .filter((_t: string) => _t.includes('Execution'))
+  const filesNameArr = fs.readdirSync(uipathFolderPath, 'utf8').filter((_t: string) => {
+    const splitedArr = _t.split('_')
+    if (splitedArr.length === 2 && _t.includes('Execution')) {
+      return true
+    }
+  })
   return filesNameArr
 }
 

--- a/server/src/core/file-name-analyzer.ts
+++ b/server/src/core/file-name-analyzer.ts
@@ -3,20 +3,27 @@ import { serverConfig } from '../app-config'
 
 import { IFileInfoObj } from '../types/log-types'
 
+// judge logs file and filter it
+export const filterLogsFile = (fileName: string) => {
+  const splitedArr = fileName.split('_')
+  if (splitedArr.length === 2 && fileName.includes('Execution')) {
+    return true
+  } else {
+    return false
+  }
+}
+
 /**
  * get all log files name
  * @param uipathFolderPath uipath log storage path
  * @returns all log files name
  */
-export const getFilesName = (uipathFolderPath: string): string[] => {
+const getFilesName = (uipathFolderPath: string): string[] => {
   // fixed: At Uipath 2019.10.* old version has `2023-02-10_WorkflowAnalyzer_Execution.log`
   // get all files name
-  const filesNameArr = fs.readdirSync(uipathFolderPath, 'utf8').filter((_t: string) => {
-    const splitedArr = _t.split('_')
-    if (splitedArr.length === 2 && _t.includes('Execution')) {
-      return true
-    }
-  })
+  const filesNameArr = fs
+    .readdirSync(uipathFolderPath, 'utf8')
+    .filter((_t: string) => filterLogsFile(_t))
   return filesNameArr
 }
 


### PR DESCRIPTION
#### Environment: 
Uipath version :  `2019.10.2`

#### Detail:
在该版本中，Logs文件夹存在以下两种目录：
 - `2023-02-10_WorkflowAnalyzer_Execution.log`    (x)
-  `2023-02-10_Execution.log`  (√)